### PR TITLE
Update the script for Linux

### DIFF
--- a/App-automation.py
+++ b/App-automation.py
@@ -19,6 +19,9 @@ sunshine_exe_path = r"C:\Program Files\Sunshine\sunshine.exe" Put your sunshine 
 
 
 def restart_steam():
+    if os.name != 'nt':
+        print("Stream restarting is not supported. Please, restart Steam manually if any game is missing.")
+        return
     print("Restarting Steam...")
     for proc in psutil.process_iter(['name']):
         if proc.name().lower() == 'steam.exe':
@@ -28,6 +31,8 @@ def restart_steam():
     time.sleep(10)  # Wait for Steam to start up
 
 def restart_sunshine():
+    if os.name != 'nt':
+        print("Sunshine restarting is not supported. Please, restart Sunshine manually.")
     print("Restarting Sunshine...")
     for proc in psutil.process_iter(['name']):
         if proc.name().lower() == 'sunshine.exe':
@@ -60,7 +65,7 @@ def fetch_grid_from_steamgriddb(app_id):
                 image = Image.open(io.BytesIO(grid_response.content))
                 grid_path = os.path.join(grids_folder, f"{app_id}.png")
                 image.save(grid_path, "PNG")
-                return f"C:/Sunshine grids/{app_id}.png"
+                return grid_path
         return None
     except Exception as e:
         print(f"Error fetching grid for AppID {app_id}: {e}")
@@ -131,9 +136,10 @@ print(f"New games to add: {[installed_games[app_id] for app_id in new_games]}")
 for app_id in new_games:
     game_name = installed_games[app_id]
     grid_path = fetch_grid_from_steamgriddb(app_id)
+    cmd = f"steam://rungameid/{app_id}" if os.name == 'nt' else f"steam steam://rungameid/{app_id}"
     new_app = {
         "name": game_name,
-        "cmd": f"steam://rungameid/{app_id}",
+        "cmd": cmd,
         "output": "",
         "detached": "",
         "elevated": "false",

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The script will:
 - If you encounter any "Access Denied" errors, try running the script with administrator privileges.
 - Ensure your SteamGridDB API key is correct and has not expired.
 - Check that all path variables in the script are correct for your system.
+- On Linux, if you are using flatpak, you may need to replace `f"steam steam://rungameid/{app_id}"` with `f"flatpak run com.valvesoftware.Steam steam://rungameid/{app_id}"`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,15 @@ Before you begin, ensure you have met the following requirements:
 - A SteamGridDB API key (get one from [SteamGridDB](https://www.steamgriddb.com/profile/preferences/api))
 
 ## Installation
-
 1. Clone this repository or download the script.
-2. Install the required Python libraries: vdf, glob, pillow and requests. You can do this by installing python (https://www.python.org/downloads/), then opening cmd and running the command "py -m pip install vdf", then glob, then pillow and finally requests. 
+2. Install the required Python libraries: vdf, glob, pillow and requests.
+- Windows: You can do this by installing python (https://www.python.org/downloads/), then opening cmd and running the command `py -m pip install vdf`, then glob, then pillow and finally requests.
+- Linux: You can do this by installing python and pip, then running `python -m pip install -r requirements.txt` in the directory.
+
+
+### Linux:
+1. Clone this repository or download the script.
+2. 
 
 ## Configuration
 
@@ -31,12 +37,16 @@ Before running the script, you need to configure a few paths and your API key:
 
 1. Open the script in a text editor.
 2. Update the following variables:
-- `library_vdf_path`: Path to your Steam library VDF file ( usually found in your main steam installation path. Example: D:\Steam\userdata\!USERIDHERE!\config\localconfig.vdf )
-- `apps_json_path`: Path to your Sunshine apps.json file ( usually found in your main sunshine installation path. Example: C:\Program Files\Sunshine\config\apps.json)
+- `library_vdf_path`: Path to your Steam library VDF file, usually found in your main steam installation path. Example: 
+  - Windows: D:\Steam\userdata\\!USERIDHERE!\config\localconfig.vdf
+  - Linux: /home/!USERIDHERE!/.local/share/Steam/steamapps/libraryfolders.vdf
+- `apps_json_path`: Path to your Sunshine apps.json file, usually found in your main sunshine installation path. Example:
+  - Windows: C:\Program Files\Sunshine\config\apps.json
+  - Linux: /home/!USERIDHERE!/.config/sunshine/apps.json
 - `grids_folder`: Path where you want to save the grid images ( I just store mine in c:\grids_folder )
 - `STEAMGRIDDB_API_KEY`: Your SteamGridDB API key
-- `steam_exe_path`: Your steam exe path
-- `sunshine_exe_path`: Your sunshine exe path
+- `steam_exe_path`: Your steam exe path (Linux users can ignore this for now)
+- `sunshine_exe_path`: Your sunshine exe path (Linux users can ignore this for now)
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+vdf
+requests
+pillow
+glob


### PR DESCRIPTION
Hi,

I made these changes locally and thought it would be nice to share them, so other users can use them too.

I added additional instructions for Linux and changed the code to check if the code is running on a Windows machine. I also changed `f"C:/Sunshine grids/{app_id}.png"` to just returning `grid_path`. You can change this if this does not work on Windows.